### PR TITLE
token_renewer: use new callback signature

### DIFF
--- a/wazo_confd/controller.py
+++ b/wazo_confd/controller.py
@@ -43,8 +43,13 @@ class Controller:
             dependencies={
                 'api': api,
                 'config': config,
-                'token_changed_subscribe': self.token_renewer.subscribe_to_token_change,
+                'token_changed_subscribe': self._token_changed_subscribe,
             }
+        )
+
+    def _token_changed_subscribe(self, callback):
+        self.token_renewer.subscribe_to_token_change(
+            lambda token: callback(token['token'])
         )
 
     def run(self):


### PR DESCRIPTION
token_renewer now passes the whole token object to callbacks